### PR TITLE
Added a check so the script doesn't reinstall ruby

### DIFF
--- a/mo-dev
+++ b/mo-dev
@@ -27,7 +27,10 @@ if [ ! -d mushroom-observer ]; then
 fi
 
 if [ -f mushroom-observer/.ruby-version ]; then
-    rvm install `cat mushroom-observer/.ruby-version`
+    if ! [[ `which ruby` =~ `cat mushroom-observer/.ruby-version` ]]; then
+        echo "Installing ruby version " `cat mushroom-observer/.ruby-version`
+        rvm install `cat mushroom-observer/.ruby-version`
+    fi
 fi
 
 cd mushroom-observer


### PR DESCRIPTION
At least for me, when it would try to reinstall it would fail with a warning, but the version of ruby in `.ruby-version` was not getting used when the script cd'd into the directory. This should make it so it only tries to install if the current ruby isn't the one specified in `.ruby-version`.
