### PR TITLE
Fixes to mo-dev script

### DIFF
--- a/mo-dev
+++ b/mo-dev
@@ -22,7 +22,7 @@ if [ ! -d /home/vagrant/.rvm ]; then
     curl -L https://get.rvm.io | bash -s stable
     source /home/vagrant/.rvm/scripts/rvm
     new_rvm=1
-    sudo gem install bundle
+    sudo gem install bundle --no-rdoc --no-ri
 else
     echo RVM installed
 fi
@@ -50,7 +50,7 @@ fi
 
 if ! [[ `gem list` =~ "bundle " ]]; then
     echo "Installing bundler"
-    gem install bundle
+    gem install bundle --no-rdoc --no-ri
 else
     echo "Bundler already installed"
 fi

--- a/mo-dev
+++ b/mo-dev
@@ -9,16 +9,25 @@ if [ ! $dir ]; then
     exit
 fi
 
+if ! [[ `dpkg -l` =~ libgmp.-dev ]]; then
+    echo Installing libgmp
+    sudo apt-get install -y libgmp3-dev
+else
+    echo libgmp already installed
+fi
+
 if [ ! -d /home/vagrant/.rvm ]; then
     echo Installing RVM
     gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
     curl -L https://get.rvm.io | bash -s stable
     source /home/vagrant/.rvm/scripts/rvm
     new_rvm=1
-    sudo gem install bundler
+    sudo gem install bundle
 else
     echo RVM installed
 fi
+
+source ~/.rvm/scripts/rvm
 
 cd $dir
 if [ ! $? -eq 0 ]; then
@@ -30,14 +39,21 @@ if [ ! -d mushroom-observer ]; then
     git clone https://github.com/MushroomObserver/mushroom-observer.git
 fi
 
-if [ -f mushroom-observer/.ruby-version ]; then
-    if ! [[ `which ruby` =~ `cat mushroom-observer/.ruby-version` ]]; then
-        echo "Installing ruby version " `cat mushroom-observer/.ruby-version`
-        rvm install `cat mushroom-observer/.ruby-version`
+cd mushroom-observer
+
+if [ -f .ruby-version ]; then
+    if ! [[ `ruby --version` =~ `cat .ruby-version` ]]; then
+        echo "Installing ruby version " `cat .ruby-version`
+        rvm install `cat .ruby-version`
     fi
 fi
 
-cd mushroom-observer
+if ! [[ `gem list` =~ "bundle " ]]; then
+    echo "Installing bundler"
+    gem install bundle
+else
+    echo "Bundler already installed"
+fi
 
 mysql -u mo -pmo mo_development -e ''
 if [ ! $? -eq 0 ]; then


### PR DESCRIPTION
I've just made a bunch of changes to get the VM to install on my laptop.  It was a real mess this time.

(Not sure why it keeps breaking, why can't it just stay fixed for a change?? :)

1. I have to "apt-get install libgmp3-dev" package.

2. I have to "source ~/.rvm/scripts/rvm" *within* mo-dev.

3. It wasn't checking correctly if the version of ruby it wants to run in /vagrant/mushroom-observer is correct.

4. I have to "gem install bundle" (not bundler, and for some reason I have to do it either as me or within /vagrant/mushroom-observer, don't ask).

I think that's it.

Anyone want to take a look at the changes before I merge it?  I don't want to break it for everyone else.  I tried to make all the changes only do something if something was explicitly missing.

-Jason