### PR TITLE
Update instructions for starting server on VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,13 @@ Start web server
 Go to VM (`vagrant ssh` or through [PuTTY][])
 
     $ cd /vagrant/mushroom-observer
+
+Start the Rails server on the VM
+
+    $ moserver
+
+or
+
     $ rails server -b 0.0.0.0
 
 Go to http://localhost:3000 in a browser on the host machine. (Note:

--- a/developer-workflow.md
+++ b/developer-workflow.md
@@ -55,7 +55,7 @@ Now on the VM:
 $ gunzip -c checkpoint_stripped.gz | mysql -u mo -pmo mo_development
 $ rake db:migrate
 $ rake lang:update
-$ rails server -b 0.0.0.0
+$ moserver
 
 ```
 Finally, delete clean.sql


### PR DESCRIPTION
Uses `moserver` to start Rails server on VM.
