### PR TITLE
Add Firefox to the `mo-focal` Vagrant box

### DIFF
--- a/VAGRANT_UPGRADES.md
+++ b/VAGRANT_UPGRADES.md
@@ -66,8 +66,8 @@ In the current case I ran:
 This results in a file called `package.box`.
 
 Ultimately this should be uploaded to `images.mushroomobserver.org` and
-moved to the directory `/images/mo` with the right ownership (`mo:mo`) and
-permissions (`644`).
+moved to the directory `/data/images/mo` with the right ownership (`mo:mo`)
+and permissions (`644`).
 
 Before doing this you may want to test it locally by changing the
 mo.vm.box_url to refer to the local file.  Just remember to

--- a/VAGRANT_UPGRADES.md
+++ b/VAGRANT_UPGRADES.md
@@ -73,8 +73,8 @@ Before doing this you may want to test it locally by changing the
 mo.vm.box_url to refer to the local file.  Just remember to
 switch it back to the real URL after you have things working.
 
-In the current case I renamed `package.box` to `mo-focal-2022-06-04.box` and updated
-the variable to point to:
+In the current case I renamed `package.box` to `mo-focal-2022-06-04.box` and
+updated the variable to point to:
 
     file:///home/nathan/src/developer-startup/mo-focal-2022-06-04.box
 

--- a/VAGRANT_UPGRADES.md
+++ b/VAGRANT_UPGRADES.md
@@ -8,7 +8,7 @@ system, the version Ruby or various other core components of the VM.
 1) Update VirtualBox and Vagrant
 
 It's recommended that you always update to the latest version of
-VirtualBox and Vagrant at the start of this process.
+[VirtualBox](https://www.virtualbox.org/wiki/Downloads) and [Vagrant](https://developer.hashicorp.com/vagrant/downloads) at the start of this process.
 
 2) Destroy or set aside any old boxes.
 
@@ -16,9 +16,9 @@ I generally just destroy the current box with:
 
     vagrant destroy
 
-However, this may be a bit risky, but you really should be able to get
-back to the old setup if needed and these boxes should not be considered
-precious.
+This may seem a bit risky, but you really should be able to get back
+to the old setup if needed (by downloading the previous box from MO)
+and these boxes should not be considered precious.
 
 You may also want to check for any other boxes that may be lingering
 and could cause issues with:
@@ -27,13 +27,13 @@ and could cause issues with:
 
 4) Update the Vagrantfile
 
-For operating system upgrades, I generally go to the Vagrant Boxes
+For operating system upgrades, I generally go to the [Vagrant Boxes](https://app.vagrantup.com/boxes/search)
 search page on the HashiCorp website and search for the OS I'm looking
 for.
 
 When doing an OS upgrade I look first for a Hashicorp box and if I there
 isn't one, then I'll look for an Ubuntu one.  In the current
-Vagrantfile we're using "ubuntu/focal64".
+Vagrantfile we're using `ubuntu/focal64`.
 
 For Ruby upgrades you will change the list that looks like:
 
@@ -42,60 +42,72 @@ For Ruby upgrades you will change the list that looks like:
 IMPORTANT: You must either change the box names in the Vagrant file or
 destroy any relevant boxes.  Vagrant gets a lot of efficiency by
 relying on cached copies of things, so make sure you clean out anything
-you can.  You can change "version_date" as a simple way to change the
+you can.  You can change `version_date` as a simple way to change the
 name of the default box.
 
-5) Build the "clean" box
+5) Build the "clean" box.
 
-In the current case I ran: "vagrant up clean-focal".  You can find the current
-names by looking in the Vagrantfile and searching for "config.vm.define".
+In the current case I ran:
+
+    vagrant up clean-focal
+
+You can find the current names by looking in the Vagrantfile and searching
+for `config.vm.define`.
 
 Currently builds generate a few red warnings/errors related signatures and
 checksums, but everything seems to be working correctly.
 
-6) Create "clean" package
+6) Create "clean" package.
 
-In the current case I ran: "vagrant package clean-focal".
+In the current case I ran:
 
-This results in a file called package.box.
+    vagrant package clean-focal
 
-Ultimately This should be uploaded to images.mushroomobserver.org and
-moved to the directory /images/mo with the right ownership (mo:mo) and
-permissions (644).
+This results in a file called `package.box`.
+
+Ultimately this should be uploaded to `images.mushroomobserver.org` and
+moved to the directory `/images/mo` with the right ownership (`mo:mo`) and
+permissions (`644`).
 
 Before doing this you may want to test it locally by changing the
 mo.vm.box_url to refer to the local file.  Just remember to
 switch it back to the real URL after you have things working.
 
-In the current case I moved package.box to mo-focal-2022-06-04.box and updated
+In the current case I renamed `package.box` to `mo-focal-2022-06-04.box` and updated
 the variable to point to:
 
-file:///home/nathan/src/developer-startup/mo-focal-2022-06-04.box
+    file:///home/nathan/src/developer-startup/mo-focal-2022-06-04.box
 
-7) Bring up the vagrant box
+7) Bring up the vagrant box.
 
-Run: vagrant up
+Run:
 
-This should bring up a version of the box with the new configuration.
+    vagrant up
 
-Now run: vagrant ssh
+This should bring up a version of the box with the new configuration. Now run:
+
+    vagrant ssh
 
 This should connect you to the new box.
 
-8) Setup the local build environment
+8) Setup the local build environment.
 
-Run: mo-dev /vagrant
+Run:
+
+    mo-dev /vagrant
 
 This will run bundler and the other bits needed to get the new box
 setup to actually run MO.
 
-9) Run the tests
+9) Run the tests.
 
-Run: cd /vagrant/mushroom-observer; rails test
+Run:
+
+    cd /vagrant/mushroom-observer; rails test
 
 If everything is green you great!
 
 If stuff fails now you have to figure out how to fix it.
 
-10) Don't forget to upload the new box to images.mushroomobserver.org
-and update box_url in the Vagrantfile.
+10) Don't forget to upload the new box to `images.mushroomobserver.org`
+and update `box_url` in the Vagrantfile.

--- a/VAGRANT_UPGRADES.md
+++ b/VAGRANT_UPGRADES.md
@@ -84,7 +84,9 @@ Run:
 
     vagrant up
 
-This should bring up a version of the box with the new configuration. Now run:
+This should bring up a version of the box with the new configuration.
+
+Now run:
 
     vagrant ssh
 
@@ -109,5 +111,7 @@ If everything is green you great!
 
 If stuff fails now you have to figure out how to fix it.
 
-10) Don't forget to upload the new box to `images.mushroomobserver.org`
-and update `box_url` in the Vagrantfile.
+10) Don't forget to update `box_url` in the Vagrantfile, and upload the new box
+to `images.mushroomobserver.org`. (You will need an ssh account on that server.)
+
+    scp /path/to/your/mo-focal-2022-12-01.box youraccount@images.mushroomobserver.org:/data/images/mo

--- a/VSCODE_WITH_VAGRANT.md
+++ b/VSCODE_WITH_VAGRANT.md
@@ -1,0 +1,39 @@
+Setting up VSCode to work on Vagrant
+=========================================================
+
+For developers who happen to be using VSCode. The goal here is to be working on the code *inside* the Vagrant box, so your localhost will reflect the code you're editing.
+
+First, install the VSCode extension **Remote - SSH**. Once it's installed, there should be a blue button in the far lower left corner of the VSCode window, with a symbol like `><`.
+
+Once that's installed, in a separate shell window, bring the Vagrant machine up:
+
+    $ vagrant up
+
+Get the SSH config for the Vagrant box on your machine. Type this:
+
+    $ vagrant ssh-config
+
+Copy the output that appears, something like this. You'll need to paste it in VS Code.
+
+    Host mo-focal-2022-12-01
+      HostName 127.0.0.1
+      User vagrant
+      Port 2222
+      UserKnownHostsFile /dev/null
+      StrictHostKeyChecking no
+      PasswordAuthentication no
+      IdentityFile /Users/<you!>/.vagrant.d/boxes/mo-focal-2022-12-01/0/virtualbox/vagrant_private_key
+      IdentitiesOnly yes
+      LogLevel FATAL
+
+Switch back to VSCode. Click that `><` blue button in the bottom left, and select `Remote-ssh: Open configuration file`. I use the config located here:
+
+    /Users/<you!>/.ssh/config
+
+Paste the config you just copied into `config`. You can rename the `Host` in the first line you pasted, to whatever you like.
+
+If there are other hosts you want to keep, don't delete them. Save the file and close.
+
+That's it! Now, the Vagrant `Host` you just pasted and maybe renamed will be available for connection. Click on the same blue icon in the lower left corner of VSCode, and `Connect Current Window to Host`. Pick the Vagrant host, and navigate to the folder for MO.
+
+Thanks to [Andrés Lopez](https://medium.com/@lopezgand/connect-visual-studio-code-with-vagrant-in-your-local-machine-24903fb4a9de) for the tutorial.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,13 +39,23 @@ Vagrant.configure("2") do |config|
       SHELL
 
       clean.vm.provision :shell, privileged: false, inline: <<-SHELL
-        gpg2 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+        # # These may be less secure than keyservers, but at least they load.
+        curl -sSL https://rvm.io/mpapis.asc | gpg --import -
+        curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
+        # Trust them keys
+        echo 409B6B1796C275462A1703113804BB82D39DC0E3:6: | gpg --import-ownertrust # mpapis@gmail.com
+        echo 7D2BAF1CF37B13E2069D6956105BD0E739499BDB:6: | gpg --import-ownertrust # piotr.kuczynski@gmail.com
+
+        # This reliably fails!
+        # gpg2 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+
         curl -L https://get.rvm.io | bash -s stable
         source ~/.rvm/scripts/rvm
-        rvm install 2.7.6
-        rvm install 3.0.4
         rvm install 3.1.2
       SHELL
+
+      # Add Firefox for selenium tests
+      config.vm.provision :shell, inline: "apt-get install -y firefox"
 
       clean.trigger.after [:provision] do |t|
         t.name = "Reboot after provisioning"
@@ -53,7 +63,7 @@ Vagrant.configure("2") do |config|
       end
     end
   else
-    version_date = "2022-06-04"
+    version_date = "2022-12-01"
     config.vm.define "mo-focal-#{version_date}", primary: true do |mo|
       mo.vm.box = "mo-focal-#{version_date}"
       mo.vm.box_url = "https://images.mushroomobserver.org/mo-focal-#{version_date}.box"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,7 +46,7 @@ Vagrant.configure("2") do |config|
         echo 409B6B1796C275462A1703113804BB82D39DC0E3:6: | gpg --import-ownertrust # mpapis@gmail.com
         echo 7D2BAF1CF37B13E2069D6956105BD0E739499BDB:6: | gpg --import-ownertrust # piotr.kuczynski@gmail.com
 
-        # This reliably fails!
+        # These keyservers reliably fail!
         # gpg2 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 
         curl -L https://get.rvm.io | bash -s stable


### PR DESCRIPTION
- Provisions vagrant box with Firefox to enable Capybara `selenium-webdriver` testing.
- Updates Ubuntu components with the `focal64` branch.
- Changes Vagrant provision of `rvm`'s public key from unreliable keyservers, to their copy on rvm.io
- Adds notes in the `Vagrantfile`
- Adds links and styling to `VAGRANT_UPGRADES.md`

