### PR TITLE
Don't try to install gems if there's no Gemfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,7 +46,9 @@ if [ ! -e /home/vagrant/.rbenv/shims/bundle ]; then
   gem install bundler
   rbenv rehash
 fi
-bundle install
+if [ -f "./mushroom-observer/Gemfile" ]; then
+  bundle install
+end
 SCRIPT
 
 # All Vagrant configuration is done below. The "2" in Vagrant.configure

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,7 +46,7 @@ if [ ! -e /home/vagrant/.rbenv/shims/bundle ]; then
   gem install bundler
   rbenv rehash
 fi
-if [ -f "./mushroom-observer/Gemfile" ]; then
+if [ -f "./Gemfile" ]; then
   bundle install
 end
 SCRIPT


### PR DESCRIPTION
My modified Vagrantfile install shell script added a "convenience" line to install your gems after installing ruby, but...

...that's not convenient if you are doing a clean install and don't have `/mushroom-observer/Gemfile` already!