### PR TITLE
libyaml-dev

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,7 +46,7 @@ mo_rbenv_script = <<~SCRIPT
   rbenv global #{RUBY_V}
   cd /vagrant/mushroom-observer
   if [ ! -e /home/vagrant/.rbenv/shims/bundle ]; then
-    gem install bundler
+    gem install bundler --no-ri --no-rdoc
     rbenv rehash
   fi
   if [ -f "./Gemfile" ]; then

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,8 +18,9 @@ mo_apt_script = <<~SCRIPT
   apt-get -y install libmysqlclient-dev
   sed "s/\\[mysqld\\]/[mysqld]\\nsql-mode = ''/" -i'' /etc/mysql/mysql.conf.d/mysqld.cnf
   ln -fs /vagrant/mo-dev /usr/local/bin/mo-dev
-  apt-get -y install git build-essential wget curl vim ruby imagemagick \
-    libmagickcore-dev libmagickwand-dev libjpeg-dev libgmp3-dev gnupg2 \
+  apt-get -y install git build-essential wget curl vim ruby \
+    imagemagick libmagickcore-dev libmagickwand-dev libjpeg-dev \
+    libgmp3-dev libyaml-dev gnupg2 \
     chromium-browser
 SCRIPT
 


### PR DESCRIPTION
- Installs libyaml-dev on the vm. That library is needed to update `psych`
- Incidentally omits documentation when installing `bundler`

https://groups.google.com/g/mo-developers/c/u7iacFJzfKU/m/5FvVK9EAAgAJ
Delivers https://www.pivotaltracker.com/story/show/186023110